### PR TITLE
Combine inverts

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -704,7 +704,7 @@ static void osd_input_update_internal_bitmasks(void)
 		     input.analog[i][1] = 128;
 	          else
 	          {
-		     if (config.invert_xe1ap == 1)
+		     if (config.invert_mouse == 1)
                         input.analog[i][1] = 255 - (config.lightgunyoffset + config.lightgunyratio * ((input_state_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y) + 0x7fff) * bitmap.viewport.h) / 0xfffe);
 		     else
 		        input.analog[i][1] = config.lightgunyoffset + config.lightgunyratio * ((input_state_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y) + 0x8000) / 256.f); 
@@ -984,7 +984,7 @@ static void osd_input_update_internal(void)
 		     input.analog[i][1] = 128;
 	          else
 	          {
-		     if (config.invert_xe1ap == 1)
+		     if (config.invert_mouse == 1)
                         input.analog[i][1] = 255 - (config.lightgunyoffset + config.lightgunyratio * (input_state_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y) + 0x8000) / 256.f);
 		     else
 		        input.analog[i][1] = config.lightgunyoffset + config.lightgunyratio * (input_state_cb(player, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y) + 0x8000) / 256.f; 
@@ -2133,15 +2133,6 @@ static void check_variables(bool first_run)
       config.invert_mouse = 0;
     else
       config.invert_mouse = 1;
-  }
-
-  var.key = "genesis_plus_gx_invert_xe1ap";
-  environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var);
-  {
-    if (!var.value || !strcmp(var.value, "disabled"))
-      config.invert_xe1ap = 0;
-    else
-      config.invert_xe1ap = 1;
   }
 
   var.key = "genesis_plus_gx_circular_paddle";

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -1187,23 +1187,9 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "genesis_plus_gx_invert_mouse",
-      "Invert Mouse Y-Axis",
+      "Invert Mouse/XE-1 AP Y-Axis",
       NULL,
-      "Inverts the Y-axis of the MD Mouse input device type.",
-      NULL,
-      "input",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      "genesis_plus_gx_invert_xe1ap",
-      "Invert XE-1 AP Y-Axis",
-      NULL,
-      "Inverts the Y-axis of the left stick of the XE-1 AP input device type.",
+      "Inverts the Y-axis of the MD Mouse and the left stick of the XE-1 AP input device types.",
       NULL,
       "input",
       {

--- a/libretro/osd.h
+++ b/libretro/osd.h
@@ -134,7 +134,6 @@ typedef struct
   float lightgunyratio;
   float lightgunxoffset;
   float lightgunyoffset;
-  uint8 invert_xe1ap;
   uint8 circularpaddle;
   uint8 gun_cursor;
   uint32 overclock;


### PR DESCRIPTION
Removed the XE1-AP specific invert option and combined it with the pre-existing Mouse invert option. 
Thought this might tidy up the options menu a little.  Feel free to reject as unnecessary if you so wish. 